### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install macropad
+    circup install adafruit_macropad
 
 Or the following command to update an existing version:
 


### PR DESCRIPTION
Fix the `circup install ...` instruction.
Tested with `circup` to a PyPortal.