### PR TITLE
Document class attributes.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,3 +6,9 @@
 
 .. automodule:: adafruit_macropad
     :members:
+
+.. autoattribute:: MacroPad.Keycode
+
+.. autoattribute:: MacroPad.ConsumerControlCode
+
+.. autoattribute:: MacroPad.Mouse


### PR DESCRIPTION
The Keycode, ConsumerControlCode and Mouse documentation were not rendering. Updated to fix that.