### PR TITLE
Compatibility with LED_Animation library

### DIFF
--- a/adafruit_macropad.py
+++ b/adafruit_macropad.py
@@ -911,6 +911,9 @@ class _PixelMapLite:
     def __repr__(self):
         return self._pixels.__repr__()
 
+    def __len__(self):
+        return len(self._pixels)
+
     @property
     def auto_write(self):
         """

--- a/examples/macropad_led_animation_example.py
+++ b/examples/macropad_led_animation_example.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2021 Tim Cocks
+# SPDX-License-Identifier: MIT
+
+"""
+This simpletest example displays the Blink animation on the
+MacroPad neopixels
+"""
+from adafruit_led_animation.animation.blink import Blink
+from adafruit_led_animation.color import BLUE
+from adafruit_macropad import MacroPad
+
+macropad = MacroPad()
+
+blink = Blink(macropad.pixels, speed=0.5, color=BLUE)
+
+while True:
+    blink.animate()


### PR DESCRIPTION
This change implements `__len__` inside of the `macropad.pixels` object which allows it to be used with the LED_Animation library. Without this code attempting to use with LED_Animation raises an exception.

I also added a very basic example that illustrates the usage with LED_Animation. The new example runs successfully on my MacroPad device. I have also tested a more complex animation inside of a separate project and found it to working fine as well.