### PR TITLE
Remove usage of max_glyphs with Label

### DIFF
--- a/examples/macropad_grid_layout.py
+++ b/examples/macropad_grid_layout.py
@@ -25,7 +25,7 @@ title = label.Label(
 layout = GridLayout(x=0, y=10, width=128, height=54, grid_size=(3, 4), cell_padding=5)
 labels = []
 for _ in range(12):
-    labels.append(label.Label(terminalio.FONT, text="", max_glyphs=10))
+    labels.append(label.Label(terminalio.FONT, text=""))
 
 for index in range(12):
     x = index % 3


### PR DESCRIPTION
Remove usage of `max_glyphs` now that it has been removed from `Adafruit_CircuitPython_Display_Text`
https://github.com/adafruit/Adafruit_CircuitPython_Display_Text/releases/tag/2.20.0

**Not tested**: I don't have a MacroPad