### PR TITLE
Remove errant line from example.

### DIFF
--- a/examples/macropad_mp3/macropad_mp3.py
+++ b/examples/macropad_mp3/macropad_mp3.py
@@ -28,4 +28,3 @@ while True:
 
         else:
             macropad.pixels.fill((0, 0, 0))
-            macropad.stop_tone()


### PR DESCRIPTION
Final line was included from different example. Not needed in this one.