### PR TITLE
Fix setting a pixels slice

### DIFF
--- a/adafruit_macropad.py
+++ b/adafruit_macropad.py
@@ -925,7 +925,7 @@ class _PixelMapLite:
     def __setitem__(self, index, val):
         if isinstance(index, slice):
             for val_i, in_i in enumerate(range(*index.indices(self._num_pixels))):
-                self._pixels[in_i] = self._order[val_i]
+                self._pixels[self._order[in_i]] = val[val_i]
         else:
             self._pixels[self._order[index]] = val
 


### PR DESCRIPTION
When setting the pixels with a slice, set the correct pixel to a value provided (not to the index).

This was discovered using `adafruit_led_animation.animation.rainbow`
```py
from adafruit_led_animation.animation.rainbow import Rainbow
rainbow = Rainbow(macropad.pixels, speed=.1, period=2)
while True:
    rainbow.animate()
```
And tested with this (with all values of rotation)
```py
from adafruit_macropad import MacroPad
import time

macropad = MacroPad(rotation=0)

macropad.pixels[:] = (
    (255,0,0), (128,255,0), (0,255,0), (0,255,128),
    (0,0,255), (128,0,255), (255,255,255), (0,0,0),
    (255,0,0), (128,255,0), (0,255,0), (0,255,128),
)
time.sleep(2)

for x in range(9):
    macropad.pixels.fill(0)
    macropad.pixels[x:x+4] = (
        (255,0,0), (0,255,0), (0,0,255), (255,255,255)
    )
    time.sleep(1)
```