### PR TITLE
lower cell_padding in the grid example

### DIFF
--- a/examples/macropad_grid_layout.py
+++ b/examples/macropad_grid_layout.py
@@ -22,7 +22,7 @@ title = label.Label(
     text="      KEYPRESSES      ",
     background_color=0xFFFFFF,
 )
-layout = GridLayout(x=0, y=10, width=128, height=54, grid_size=(3, 4), cell_padding=5)
+layout = GridLayout(x=0, y=10, width=128, height=54, grid_size=(3, 4), cell_padding=1)
 labels = []
 for _ in range(12):
     labels.append(label.Label(terminalio.FONT, text=""))


### PR DESCRIPTION
This is a tweak to lower the cell padding in the grid example to account for a fix inside of GridLayout from DisplayIO_Layouts PR  [#48](https://github.com/adafruit/Adafruit_CircuitPython_DisplayIO_Layout/pull/48)

If that PR is merged as it is now this should be merged at the same time to account for a difference in the way that labels are positioned.

Using the version of GridLayout in that PR along with this change this example should appear roughly the same on the screen as the current version does now with the currently released version of GridLayout

here is how the example looks on the display using the updated code from that PR and this change: 
![image](https://user-images.githubusercontent.com/2406189/131599165-76104c70-dfde-4140-9a1d-a31f6dffc19f.png)
