### PR TITLE
Maybe fixed patch CI by tweaking docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -8,7 +8,10 @@
     :members:
 
 .. autoattribute:: MacroPad.Keycode
+    :noindex:
 
 .. autoattribute:: MacroPad.ConsumerControlCode
+    :noindex:
 
 .. autoattribute:: MacroPad.Mouse
+    :noindex:


### PR DESCRIPTION
I did some editing to try to get sphinx to build without any errors. First picture is how it looked when I built the maybe fixed version locally and the second picture is how the docs look online now.

Here's how it looks now:
![new](https://user-images.githubusercontent.com/33632497/150422377-32e48583-532b-40b7-a04f-0bdda57d06ab.png)
Here's the current online version
<img width="749" alt="Screen Shot 2022-01-20 at 4 05 25 PM" src="https://user-images.githubusercontent.com/33632497/150422396-92109b83-61bb-4e43-bd3f-0d96bb891c73.png">
