### PR TITLE
Adding check before usb_midi setup during init

### DIFF
--- a/adafruit_macropad.py
+++ b/adafruit_macropad.py
@@ -256,7 +256,7 @@ class MacroPad:
         self._mouse = None
 
         # Define MIDI:
-        if len(usb_midi.ports) == 2:
+        try:
             self._midi = adafruit_midi.MIDI(
                 midi_in=usb_midi.ports[0],
                 # MIDI uses channels 1-16. CircuitPython uses 0-15. Ergo -1.
@@ -264,7 +264,8 @@ class MacroPad:
                 midi_out=usb_midi.ports[1],
                 out_channel=midi_out_channel - 1,
             )
-        else:
+        except IndexError:
+            # No MIDI ports available.
             self._midi = None
 
     Keycode = Keycode

--- a/adafruit_macropad.py
+++ b/adafruit_macropad.py
@@ -256,13 +256,16 @@ class MacroPad:
         self._mouse = None
 
         # Define MIDI:
-        self._midi = adafruit_midi.MIDI(
-            midi_in=usb_midi.ports[0],
-            # MIDI uses channels 1-16. CircuitPython uses 0-15. Ergo -1.
-            in_channel=midi_in_channel - 1,
-            midi_out=usb_midi.ports[1],
-            out_channel=midi_out_channel - 1,
-        )
+        if len(usb_midi.ports) == 2:
+            self._midi = adafruit_midi.MIDI(
+                midi_in=usb_midi.ports[0],
+                # MIDI uses channels 1-16. CircuitPython uses 0-15. Ergo -1.
+                in_channel=midi_in_channel - 1,
+                midi_out=usb_midi.ports[1],
+                out_channel=midi_out_channel - 1,
+            )
+        else:
+            self._midi = None
 
     Keycode = Keycode
     """


### PR DESCRIPTION
This addressses #33 by making sure `usb_midi.ports` has the appropriate, expected length (`2`) before attempting to set up `adafruit_midi`.

I was hoping to find a `bool` within `usb_midi` that would offer a cleaner way to check enable status but the length of the `ports` property looked like the simplest way to determine state. If enabled, it'll always be `2` - `[0]` for input, `[1]` for output.

Without this check, if `usb_midi` is disabled in `boot.py` instatiation of a `MacroPad()` object will fail with an index exception.