### PR TITLE
Updated documentation to include missing dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,10 @@ This driver depends on:
 * `Adafruit's CircuitPython Debouncer library
   <https://github.com/adafruit/Adafruit_CircuitPython_Debouncer>`_
 
+* `Adafruit's CircuitPython Ticks library
+  <https://github.com/adafruit/Adafruit_CircuitPython_Ticks>`_
+  
+
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading
 `the Adafruit library and driver bundle <https://circuitpython.org/libraries>`_

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ This driver depends on:
 
 * `Adafruit's CircuitPython Ticks library
   <https://github.com/adafruit/Adafruit_CircuitPython_Ticks>`_
-  
+
 
 Please ensure all dependencies are available on the CircuitPython filesystem.
 This is easily achieved by downloading

--- a/adafruit_macropad.py
+++ b/adafruit_macropad.py
@@ -40,7 +40,7 @@ Implementation Notes
 
 * Adafruit's CircuitPython Debouncer library:
   https://github.com/adafruit/Adafruit_CircuitPython_Debouncer
-  
+
 * Adafruit's CircuitPython Ticks library
   https://github.com/adafruit/Adafruit_CircuitPython_Ticks
 

--- a/adafruit_macropad.py
+++ b/adafruit_macropad.py
@@ -40,6 +40,9 @@ Implementation Notes
 
 * Adafruit's CircuitPython Debouncer library:
   https://github.com/adafruit/Adafruit_CircuitPython_Debouncer
+  
+* Adafruit's CircuitPython Ticks library
+  https://github.com/adafruit/Adafruit_CircuitPython_Ticks
 
 """
 


### PR DESCRIPTION
While getting started with the MacroPad I found that use of the macropad library also required the **adafruit_ticks** library which was not documented as a dependency.