### PR TITLE
Add arguments to setup layout on init

### DIFF
--- a/examples/macropad_keyboard_layout.py
+++ b/examples/macropad_keyboard_layout.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021 Kattni Rembor for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+"""
+International layout demo for MacroPad.
+"""
+import time
+from keyboard_layout_win_fr import KeyboardLayout
+from keycode_win_fr import Keycode
+from adafruit_macropad import MacroPad
+
+macropad = MacroPad(
+    layout_class=KeyboardLayout,
+    keycode_class=Keycode,
+)
+
+keycodes = [
+    "https://adafruit.com/",
+    "https://adafru.it/discord",
+    "https://circuitpython.org",
+    Keycode.A,
+    Keycode.D,
+    Keycode.A,
+    Keycode.F,
+    Keycode.R,
+    Keycode.U,
+    Keycode.I,
+    Keycode.T,
+    Keycode.PERIOD,
+    #    Keycode.C, Keycode.O, Keycode.M,
+]
+
+while True:
+    key_event = macropad.keys.events.get()
+    if key_event:
+        keycode = keycodes[key_event.key_number]
+        if key_event.pressed:
+            if isinstance(keycode, int):
+                macropad.keyboard.press(keycode)
+            else:
+                macropad.keyboard_layout.write(keycode)
+        else:
+            if isinstance(keycode, int):
+                macropad.keyboard.release(keycode)
+    time.sleep(0.05)


### PR DESCRIPTION
This adds parameters to the init of the `Macropad` class to allow defining a keyboard layout that is not the default US.

The parameters are classes, the layout class from which the layout is instanciated, and the keycode class, from which the class constants are taken. It is assigend to the class property Macropad.Keycode, for use in the code.

The added example shows how it is used.
```py
from keyboard_layout_win_fr import KeyboardLayout
from keycode_win_fr import Keycode
from adafruit_macropad import MacroPad

macropad = MacroPad(
    layout_class=KeyboardLayout,
    keycode_class=Keycode,
)

macropad.keyboard_layout.write("Hello world !")
```

---- 

I've also added a reference variable to the Keycode class at the module level. This is to help with the hotkeys code for example. It allows doing this in the macros files, and have it use the Keycode set in code.py.
```py
from adafruit_macropad import Keycode
```
I don't know if that's really a good thing in general, it could simply be done by having the Keycode setting in a separate file for example. And it won't work in general if you want to instantiate 2 Macropad instances with different languages at the same time.