### PR TITLE
Fix Issue 40: Docs rendering improperly for keys function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ _build
 
 # Virtual environment-specific files
 .env
+.venv
 
 # MacOS-specific files
 *.DS_Store

--- a/adafruit_macropad.py
+++ b/adafruit_macropad.py
@@ -397,8 +397,9 @@ class MacroPad:
         * ``key_number``: the number of the key that changed. Keys are numbered starting at 0.
         * ``pressed``: ``True`` if the event is a transition from released to pressed.
         * ``released``: ``True`` if the event is a transition from pressed to released.
-            ``released`` is always the opposite of ``pressed``; it's provided for convenience
-            and clarity, in case you want to test for key-release events explicitly.
+
+        ``released`` is always the opposite of ``pressed``; it's provided for convenience
+        and clarity, in case you want to test for key-release events explicitly.
 
         The following example prints the key press and release events to the serial console.
 

--- a/adafruit_macropad.py
+++ b/adafruit_macropad.py
@@ -397,9 +397,8 @@ class MacroPad:
         * ``key_number``: the number of the key that changed. Keys are numbered starting at 0.
         * ``pressed``: ``True`` if the event is a transition from released to pressed.
         * ``released``: ``True`` if the event is a transition from pressed to released.
-                        ``released`` is always the opposite of ``pressed``; it's provided
-                        for convenience and clarity, in case you want to test for
-                        key-release events explicitly.
+            ``released`` is always the opposite of ``pressed``; it's provided for convenience
+            and clarity, in case you want to test for key-release events explicitly.
 
         The following example prints the key press and release events to the serial console.
 


### PR DESCRIPTION
This PR does two things:

1 - Update gitignore to include .venv, otherwise pre-commit fails

2 - Fixes the improper bold text in the keys function

This is my first docs PR - if I need to change or update anything, please let me know. 

Thanks!