### PR TITLE
Update font documentation for display_text()

### DIFF
--- a/adafruit_macropad.py
+++ b/adafruit_macropad.py
@@ -899,9 +899,10 @@ class MacroPad:
                                  Defaults to 80.
         :param int text_scale: Scale the size of the data lines. Scales the title as well.
                                Defaults to 1.
-        :param font: The font or the path to the custom font file to use to display the text.
-                     Defaults to the built-in ``terminalio.FONT``. The ``font`` argument must be of
-                     a type that subclasses ``FontProtocol``. For more details, see:
+        :param ~FontProtocol|None font: The font or the path to the custom font file to use to
+                     display the text. Defaults to the built-in ``terminalio.FONT``. The ``font``
+                     argument must be of a type that subclasses ``FontProtocol``. For more details,
+                     see:
                      https://docs.circuitpython.org/en/latest/shared-bindings/fontio/index.html
 
         The following example displays a title and lines of text indicating which key is pressed,

--- a/adafruit_macropad.py
+++ b/adafruit_macropad.py
@@ -899,11 +899,9 @@ class MacroPad:
                                  Defaults to 80.
         :param int text_scale: Scale the size of the data lines. Scales the title as well.
                                Defaults to 1.
-        :param ~FontProtocol|None font: The font or the path to the custom font file to use to
-                     display the text. Defaults to the built-in ``terminalio.FONT``. The ``font``
-                     argument must be of a type that subclasses ``FontProtocol``. For more details,
-                     see:
-                     https://docs.circuitpython.org/en/latest/shared-bindings/fontio/index.html
+        :param ~FontProtocol|None font: The custom font to use to display the text. Defaults to the
+                                        built-in ``terminalio.FONT``. For more details, see:
+                                        https://docs.circuitpython.org/en/latest/shared-bindings/fontio/index.html
 
         The following example displays a title and lines of text indicating which key is pressed,
         the relative position of the rotary encoder, and whether the encoder switch is pressed.

--- a/adafruit_macropad.py
+++ b/adafruit_macropad.py
@@ -900,8 +900,9 @@ class MacroPad:
         :param int text_scale: Scale the size of the data lines. Scales the title as well.
                                Defaults to 1.
         :param font: The font or the path to the custom font file to use to display the text.
-                     Defaults to the built-in ``terminalio.FONT``. Custom font files must be
-                     provided as a string, e.g. ``"/Arial12.bdf"``.
+                     Defaults to the built-in ``terminalio.FONT``. The ``font`` argument must be of
+                     a type that subclasses ``FontProtocol``. For more details, see:
+                     https://docs.circuitpython.org/en/latest/shared-bindings/fontio/index.html
 
         The following example displays a title and lines of text indicating which key is pressed,
         the relative position of the rotary encoder, and whether the encoder switch is pressed.
@@ -909,11 +910,14 @@ class MacroPad:
 
         .. code-block:: python
 
+            from adafruit_bitmap_font import bitmap_font
             from adafruit_macropad import MacroPad
+            from displayio import Bitmap
 
             macropad = MacroPad()
 
-            text_lines = macropad.display_text(title="MacroPad Info")
+            custom_font = bitmap_font.load_font("/Arial12.bdf", Bitmap)
+            text_lines = macropad.display_text(title="MacroPad Info", font=custom_font)
 
             while True:
                 key_event = macropad.keys.events.get()


### PR DESCRIPTION
The current `display_text()` documentation is incorrect in my testing. It is not sufficient to simply provide a font file path string to the `font` argument of this method. You must provide the font in the form of an object which subclasses `FontProtocol` or otherwise provides the `get_bounding_box()` and `get_glyph()` methods. I am proposing this change to the documentation to clear up the usage of this parameter.